### PR TITLE
fix 2.0.2 for Navi (wave32)

### DIFF
--- a/src/tree/gpu_hist/evaluate_splits.cu
+++ b/src/tree/gpu_hist/evaluate_splits.cu
@@ -13,15 +13,9 @@
 
 #if defined(XGBOOST_USE_HIP)
 #include <hip/hip_cooperative_groups.h>
+#include <GPUTreeShap/gpu_treeshap.h>
 
-#ifdef __AMDGCN_WAVEFRONT_SIZE
-#undef WAVEFRONT_SIZE
-#define WAVEFRONT_SIZE __AMDGCN_WAVEFRONT_SIZE
-#endif
-
-#define WARP_SIZE WAVEFRONT_SIZE
-#elif defined(XGBOOST_USE_CUDA)
-#define WARP_SIZE 32
+int warp_size_hip_xgb = 0;
 #endif
 
 namespace xgboost::tree {
@@ -96,11 +90,15 @@ class EvaluateSplitAgent {
         parent_sum(dh::LDGIterator<GradientPairInt64>(&inputs.parent_sum)[0]),
         param(shared_inputs.param), evaluator(evaluator),
         missing(parent_sum - ReduceFeature()) {
+#if defined(XGBOOST_USE_CUDA)
     static_assert(
         kBlockSize == WARP_SIZE,
         "This kernel relies on the assumption block_size == warp_size");
+#endif
     // There should be no missing value gradients for a dense matrix
+#if !defined(XGBOOST_USE_HIP) // disable on Navi due to a ROCm bug
     KERNEL_CHECK(!shared_inputs.is_dense || missing.GetQuantisedHess() == 0);
+#endif
   }
   __device__ GradientPairInt64 ReduceFeature() {
     GradientPairInt64 local_sum;
@@ -388,7 +386,21 @@ void GPUHistEvaluator::LaunchEvaluateSplits(
   dh::TemporaryArray<DeviceSplitCandidate> feature_best_splits(
       combined_num_features, DeviceSplitCandidate());
 
+  // chck warp size
+#if defined(XGBOOST_USE_HIP)
+  int WARP_SIZE = 0;
+  if (warp_size_hip_xgb <= 0) {
+    dh::safe_cuda(hipDeviceGetAttribute(&warp_size_hip_xgb, hipDeviceAttributeWarpSize, 0));
+    if (warp_size_hip_xgb <= 0) {
+      printf("failed to detect wavefront size...\n");
+      exit(-1);
+    }
+  }
+  WARP_SIZE = warp_size_hip_xgb;
+#endif
+
   // One block for each feature
+#if defined(XGBOOST_USE_CUDA)
   uint32_t constexpr kBlockThreads = WARP_SIZE;
   dh::LaunchKernel {static_cast<uint32_t>(combined_num_features), kBlockThreads,
                     0}(
@@ -396,6 +408,26 @@ void GPUHistEvaluator::LaunchEvaluateSplits(
       shared_inputs,
       this->SortedIdx(d_inputs.size(), shared_inputs.feature_values.size()),
       evaluator, dh::ToSpan(feature_best_splits));
+#elif defined(XGBOOST_USE_HIP)
+  if (WARP_SIZE == 32) {
+    uint32_t constexpr kBlockThreads = 32;
+    dh::LaunchKernel {static_cast<uint32_t>(combined_num_features), kBlockThreads,
+        0}(
+      EvaluateSplitsKernel<kBlockThreads>, max_active_features, d_inputs,
+      shared_inputs,
+      this->SortedIdx(d_inputs.size(), shared_inputs.feature_values.size()),
+      evaluator, dh::ToSpan(feature_best_splits));
+  }
+  else if (WARP_SIZE == 64) {
+    uint32_t constexpr kBlockThreads = 64;
+    dh::LaunchKernel {static_cast<uint32_t>(combined_num_features), kBlockThreads,
+        0}(
+      EvaluateSplitsKernel<kBlockThreads>, max_active_features, d_inputs,
+      shared_inputs,
+      this->SortedIdx(d_inputs.size(), shared_inputs.feature_values.size()),
+      evaluator, dh::ToSpan(feature_best_splits));
+  }
+#endif
 
   // Reduce to get best candidate for left and right child over all features
   auto reduce_offset =


### PR DESCRIPTION
The tests passed on wave32 and wave64. On wave32, rocm 6.3.4 has unknown code gen bug and the tests were on Debug build.